### PR TITLE
Add save method to ShapePlotter

### DIFF
--- a/geomfum/plot.py
+++ b/geomfum/plot.py
@@ -25,6 +25,10 @@ class ShapePlotter(abc.ABC):
     def show(self):
         """Display plot."""
 
+    @abc.abstractmethod
+    def save(self, filename):
+        """Save plot to file."""
+
     def set_vertex_scalars(self, scalars):
         """Set vertex scalars on mesh."""
         raise NotImplementedError("Not implemented for this plotter.")

--- a/geomfum/wrap/plotly.py
+++ b/geomfum/wrap/plotly.py
@@ -81,3 +81,13 @@ class PlotlyMeshPlotter(ShapePlotter):
     def show(self):
         """Display plot."""
         self._plotter.show()
+
+    def save(self, filename):
+        """Save plot to file.
+
+        Parameters
+        ----------
+        filename : str
+            Location to write file to.
+        """
+        self._plotter.write_image(filename)

--- a/geomfum/wrap/polyscope.py
+++ b/geomfum/wrap/polyscope.py
@@ -71,3 +71,13 @@ class PsMeshPlotter(ShapePlotter):
     def show(self):
         """Display plot."""
         self._plotter.show()
+
+    def save(self, filename):
+        """Save plot to file.
+
+        Parameters
+        ----------
+        filename : str | Path | io.BytesIO
+            Location to write file to.
+        """
+        self._plotter.screenshot(filename)

--- a/geomfum/wrap/pyvista.py
+++ b/geomfum/wrap/pyvista.py
@@ -79,3 +79,13 @@ class PvMeshPlotter(ShapePlotter):
         """Display plot."""
         self._add_mesh(self._mesh)
         self._plotter.show()
+
+    def save(self, filename):
+        """Save plot to file.
+
+        Parameters
+        ----------
+        filename : str | Path | io.BytesIO
+            Location to write file to.
+        """
+        self._plotter.screenshot(filename)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ test = [
     "polpo@git+https://github.com/geometric-intelligence/polpo.git@main",
     "geomfum[opt,test-scripts,plotting-all]",
 ]
-plotly = ["plotly", "nbformat"]
+plotly = ["plotly", "nbformat", "kaleido"]
 pyvista = ["pyvista", "trame"]
 polyscope = ["polyscope"]
 plotting-all = ["geomfum[plotly,pyvista,polyscope]"]


### PR DESCRIPTION
This is an implementation for issue #89.
I added the save method to ShapePlotter as an abstract method and implemented it in the concrete classes.
I'm not entirely sure it should be an abstract method, would it make sense for a plotter to not have a method to save the plot in image format?
The name of the method `save` might be ambiguous, maybe we could use a different alternative.